### PR TITLE
Update minimum supported version

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,6 @@
 name: thisnotthat
 dependencies:
-  - python>=3.7
+  - python>=3.9
   - panel
   - bokeh
   - numpy>=1.22

--- a/setup.py
+++ b/setup.py
@@ -42,8 +42,6 @@ CLASSIFIERS = ['Intended Audience :: Science/Research',
                'Operating System :: POSIX',
                'Operating System :: Unix',
                'Operating System :: MacOS',
-               'Programming Language :: Python :: 3.7',
-               'Programming Language :: Python :: 3.8',
                'Programming Language :: Python :: 3.9',
                'Programming Language :: Python :: 3.10'
                ]


### PR DESCRIPTION
If you try to pip install in an environment with python 3.7 or 3.8 the installation will fail. One of the dependencies [glasbey](https://github.com/lmcinnes/glasbey) only supports python 3.9 and above.