### PR TITLE
[MINOR] Correct BSD license in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -96,7 +96,7 @@ you and get your code merged into the main branch.
 License
 -------
 
-The This Not That package is 2-clause BSD licensed.
+The This Not That package is 3-clause BSD licensed.
 
 
 .. _Panel library: https://panel.holoviz.org/


### PR DESCRIPTION
The LICENSE file is the 3-clause BSD license.