### PR TITLE
Time-based selection of points

### DIFF
--- a/thisnotthat/__init__.py
+++ b/thisnotthat/__init__.py
@@ -10,6 +10,7 @@ from .search import (
 from .instance_viewer import InformationPane
 from .deckgl_plot import DeckglPlotPane
 from .plot_controls import PlotControlWidget
+from .selector import TimeSelectorWidget
 from .map_cluster_labelling import JointVectorLabelLayers, MetadataLabelLayers
 from thisnotthat.summary.plot import PlotSummaryPane
 from thisnotthat.summary.dataframe import DataSummaryPane
@@ -40,4 +41,5 @@ __all__ = [
     "PlotSummaryPane",
     "SampleLabelLayers",
     "SparseMetadataLabelLayers",
+    "TimeSelectorWidget",
 ]

--- a/thisnotthat/selector.py
+++ b/thisnotthat/selector.py
@@ -1,0 +1,21 @@
+import pandas as pd
+import panel as pn
+from typing import *
+
+
+class TimeSelectorWidget(pn.widgets.DatetimeRangeSlider):
+
+    def __init__(self, series_time: pd.Series, step: int = 1000, **opts) -> None:
+        self._time = series_time.copy().reset_index(drop=True)
+        m = self._time.min()
+        M = self._time.max()
+        super().__init__(start=m, end=M, value=(m, M), step=step, **opts)
+        self._plot = None
+        self.link(None, callbacks={"value": self._on_change})
+
+    def _on_change(self, _, event) -> None:
+        if self._plot:
+            self._plot.selected = self._time.loc[self._time.between(*event.new)].index.to_list()
+
+    def link_to_plot(self, plot) -> None:
+        self._plot = plot

--- a/thisnotthat/summary/plot.py
+++ b/thisnotthat/summary/plot.py
@@ -387,7 +387,7 @@ class TimeSeriesSummarizer:
         self.freq = freq
         self.fixed_time_range = fixed_time_range
 
-    def summarize(self, selected):
+    def summarize(self, selected, width=600, height=600):
         """
         A function necessary for all summarizers.  It takes a set indices specified by selected and returns a bokeh plot to
         be displayed.
@@ -417,6 +417,8 @@ class TimeSeriesSummarizer:
         fig = bpl.figure(
             x_axis_type="datetime",
             title=f"first = {df[self.time_column].min()}, last = {df[self.time_column].max()}",
+            width=width,
+            height=height,
         )
         fig.vbar(x=self.time_column, top=self.count_column, width=10, source=source)
         return fig

--- a/thisnotthat/summary/plot.py
+++ b/thisnotthat/summary/plot.py
@@ -128,10 +128,6 @@ class PlotSummaryPane(pn.reactive.Reactive):
 
     @param.depends("selected", watch=True)
     def _update_selected(self) -> None:
-        # self.pane[0] = pn.pane.Bokeh(
-        #     fig,
-        #     **self._geometry_pane
-        # )
         if time.perf_counter() * 1000.0 - self._last_update > self.throttle:
             self.summary_plot.object = (
                 self.summarizer.summarize(self.selected, **self._geometry_figure)
@@ -332,15 +328,11 @@ class JointWordCloudSummarizer:
         }
         fig = bpl.figure(title=f"Word Cloud Summary of Labels", width=width, height=height)
         word_cloud = WordCloud(
-            # font_path="arial",
             background_color=self.background_color,
             width=fig.width // 3,
             height=fig.height // 3,
             scale=4.0,
         ).generate_from_frequencies(self._word_dict)
-        # for (word, count), font_size, position, orientation, color in word_cloud.layout_:
-        #     fig.text(x=[0], y=[0], x_offset=3 * position[1], y_offset=-3 * position[0], text=[word], text_alpha=0.8, text_font={"value": "DroidSansMono"}, text_font_size=f"{font_size}px", text_color=color, angle=90 if orientation == "ROTATE_90" else 0, angle_units="deg")
-        #     print((word, count), font_size, position, orientation, color)
         pil_image = word_cloud.to_image()
         bokeh_image = bokeh_image_from_pil(pil_image)
         fig.image_rgba(


### PR DESCRIPTION
Also adds a "plot-all" parameter value to no-selection plot summary panes: this will make it so when no point is selected, the summarizer is made to summarize all the points of the dataset, and the pane to represent the result. This works really well for time-based count summaries.