### PR TITLE
Change affinity parameter to metric

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ panel
 param
 pandas
 matplotlib
-scikit-learn
+scikit-learn>=1.2.0
 numpy>=1.22
 umap-learn
 hdbscan

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ INSTALL_REQUIRES = [
     "pandas",
     "panel",
     "param",
-    "scikit-learn",
+    "scikit-learn>=1.2.0",
     "umap-learn",
     "vectorizers",
     "wordcloud",

--- a/thisnotthat/map_cluster_labelling.py
+++ b/thisnotthat/map_cluster_labelling.py
@@ -340,7 +340,7 @@ def build_cluster_layers(
 
         layer_metaclusters = AgglomerativeClustering(
             n_clusters=n_clusters,
-            affinity="euclidean",
+            metric="euclidean",
             linkage="complete",
         ).fit_predict(locations_for_clusters)
 


### PR DESCRIPTION
AgglomerativeClustering parameter was renamed to metric and [fully deprecated in sklearn 1.4](https://scikit-learn.org/1.3/modules/generated/sklearn.cluster.AgglomerativeClustering.html#sklearn-cluster-agglomerativeclustering)

